### PR TITLE
[#172348570] Azurite dockerfile and mailhog

### DIFF
--- a/azurite/Dockerfile
+++ b/azurite/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:10.14.2-alpine as builder
+
+WORKDIR /opt/azurite
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
+
+RUN git clone https://github.com/Azure/Azurite /opt/azurite && \
+    git checkout legacy-master
+
+RUN npm install
+
+FROM node:10.14.2-alpine
+
+COPY --from=builder /opt/azurite /opt/azurite
+
+WORKDIR /opt/azurite
+
+VOLUME /opt/azurite/folder
+
+ENV executable azurite
+
+CMD ["sh", "-c", "node bin/${executable} -l /opt/azurite/folder"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,14 @@ services:
     networks:
       - io-fn
 
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - 1025:1025 # smtp server
+      - 8025:8025 # web ui
+    networks:
+      - io-fn
+
 networks:
   io-fn:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,90 @@ services:
     networks:
       - io-fn
 
+  fn-admin-storage:
+    image: azurite
+    build:
+      context: ./
+      dockerfile: azurite/Dockerfile
+    ports:
+      - "10000:10000"
+      - "10001:10001"
+      - "10002:10002"
+    networks:
+      - io-fn
+
+  fn-app-storage:
+    image: azurite
+    command: ["sh", "-c", "node bin/azurite -l /opt/azurite/folder --blobPort 10003 --queuePort 10004 --tablePort 10005"]
+    ports:
+      - "10003:10003"
+      - "10004:10004"
+      - "10005:10005"
+    depends_on:
+      - fn-admin-storage
+    networks:
+      - io-fn
+
+  fn-public-storage:
+    image: azurite
+    command: ["sh", "-c", "node bin/azurite -l /opt/azurite/folder --blobPort 10006 --queuePort 10007 --tablePort 10008"]
+    ports:
+      - "10006:10006"
+      - "10007:10007"
+      - "10008:10008"
+    depends_on:
+      - fn-admin-storage
+    networks:
+      - io-fn
+
+  fn-service-storage:
+    image: azurite
+    command: ["sh", "-c", "node bin/azurite -l /opt/azurite/folder --blobPort 10009 --queuePort 10010 --tablePort 10011"]
+    ports:
+      - "10009:10009"
+      - "10010:10010"
+      - "10011:10011"
+    depends_on:
+      - fn-admin-storage
+    networks:
+      - io-fn
+
+  assets-storage:
+    image: azurite
+    command: ["sh", "-c", "node bin/azurite -l /opt/azurite/folder --blobPort 10012 --queuePort 10013 --tablePort 10014"]
+    ports:
+      - "10012:10012"
+      - "10013:10013"
+      - "10014:10014"
+    depends_on:
+      - fn-admin-storage
+    networks:
+      - io-fn
+
+  logs-storage:
+    image: azurite
+    command: ["sh", "-c", "node bin/azurite -l /opt/azurite/folder --blobPort 10015 --queuePort 10016 --tablePort 10017"]
+    ports:
+      - "10015:10015"
+      - "10016:10016"
+      - "10017:10017"
+    depends_on:
+      - fn-admin-storage
+    networks:
+      - io-fn
+
+  queue-storage:
+    image: azurite
+    command: ["sh", "-c", "node bin/azurite -l /opt/azurite/folder --blobPort 10018 --queuePort 10019 --tablePort 10020"]
+    ports:
+      - "10018:10018"
+      - "10019:10019"
+      - "10020:10020"
+    depends_on:
+      - fn-admin-storage
+    networks:
+      - io-fn
+
 networks:
   io-fn:
     driver: bridge


### PR DESCRIPTION
This PR aims to add the Dockerfile needed to build a storage account container and to use its image in the docker-compose file in order to create the required storages. It also adds the mailhog service to the docker-compose file.