### PR TITLE
Startup optimisation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - "traefik.enable=false"
 
   notificationhub:
-    image: notificationhub
+    image: notificationhub:${NOTIFICATION_HUB_COMMIT_SHA}
     build:
       context: ${NOTIFICATION_HUB_CONTEXT}
       dockerfile: ./Dockerfile
@@ -51,7 +51,7 @@ services:
       - "./io-backend/certs:/usr/src/app/certs:cached"
 
   io-bonus-inps-mock:
-    image: io-bonus-inps-mock
+    image: io-bonus-inps-mock:${IO_BONUS_INPS_MOCK_COMMIT_SHA}
     build:
       context: ${IO_BONUS_INPS_MOCK_CONTEXT}
       dockerfile: ./Dockerfile
@@ -70,7 +70,7 @@ services:
     command: /bin/true
 
   functions-admin:
-    image: io-functions-admin
+    image: io-functions-admin:${FUNCTIONS_ADMIN_COMMIT_SHA}
     build:
       context: ${FUNCTIONS_ADMIN_CONTEXT}
       dockerfile: ./Dockerfile
@@ -95,7 +95,7 @@ services:
       - "traefik.http.routers.functions-admin.middlewares=testHeader,fn-admin-stripprefix"
 
   functions-app:
-    image: io-functions-app
+    image: io-functions-app:${FUNCTIONS_APP_COMMIT_SHA}
     build:
       context: ${FUNCTIONS_APP_CONTEXT}
       dockerfile: ./Dockerfile
@@ -119,7 +119,7 @@ services:
       - "traefik.http.routers.functions-app.entrypoints=web"
 
   functions-public:
-    image: io-functions-public
+    image: io-functions-public:${FUNCTIONS_PUBLIC_COMMIT_SHA}
     build:
       context: ${FUNCTIONS_PUBLIC_CONTEXT}
       dockerfile: ./Dockerfile
@@ -141,7 +141,7 @@ services:
       - "traefik.http.routers.functions-public.entrypoints=web"
 
   functions-services:
-    image: io-functions-services
+    image: io-functions-services:${FUNCTIONS_SERVICES_COMMIT_SHA}
     build:
       context: ${FUNCTIONS_SERVICES_CONTEXT}
       dockerfile: ./Dockerfile
@@ -166,7 +166,7 @@ services:
       - "traefik.http.routers.functions-services.middlewares=testHeader,fn-services-stripprefix"
 
   functions-bonus:
-    image: io-functions-bonus
+    image: io-functions-bonus #:${FUNCTIONS_BONUS_COMMIT_SHA}
     build:
       context: ${FUNCTIONS_BONUS_CONTEXT}
       dockerfile: ./Dockerfile
@@ -188,7 +188,7 @@ services:
       - "traefik.http.routers.functions-bonus.entrypoints=web"
 
   functions-paymentmanager:
-    image: io-functions-paymentmanager
+    image: io-functions-paymentmanager:${FUNCTIONS_PAYMENTMANAGER_COMMIT_SHA}
     build:
       context: ${FUNCTIONS_PAYMENTMANAGER_CONTEXT}
       dockerfile: ./Dockerfile
@@ -210,7 +210,7 @@ services:
       - "traefik.http.routers.functions-paymentmanager.entrypoints=web"
 
   backend:
-    image: io-backend
+    image: io-backend:${IO_BACKEND_COMMIT_SHA}
     build:
       context: ${IO_BACKEND_CONTEXT}
       dockerfile: ./Dockerfile
@@ -235,7 +235,7 @@ services:
       - "./io-backend/certs:/usr/src/app/certs:cached"
 
   pagopa-proxy:
-    image: io-pagopa-proxy
+    image: io-pagopa-proxy:${IO_PAGOPA_PROXY_COMMIT_SHA}
     build:
       context: ${IO_PAGOPA_PROXY_CONTEXT}
       dockerfile: ./Dockerfile
@@ -252,7 +252,7 @@ services:
       - redis
 
   pagopa-nodo-mock:
-    image: io-pagopa-nodo-mock
+    image: io-pagopa-nodo-mock:${IO_PAGOPA_NODO_MOCK_COMMIT_SHA}
     build:
       context: ${IO_PAGOPA_NODO_MOCK_CONTEXT}
       dockerfile: ./Dockerfile

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "generate:env-fixtures": "dotenv -e generated-env/.env envsub env.io-fixtures generated-env/env.io-fixtures",
     "generate:env-cosmosdb": "dotenv -e generated-env/.env envsub env.cosmosdb generated-env/env.cosmosdb",
     "prestart": "npm-run-all generate",
-    "start": "docker-compose --env-file generated-env/.env up --build",
+    "start": "docker-compose --env-file generated-env/.env up",
     "stop": "docker-compose down"
   },
   "devDependencies": {


### PR DESCRIPTION
Avoid building an application image again when code isn't changed. 

The trick is that built images are tagged with the sha of the commit they ship; as the latest sha is always fetched before startup, if docker reckognise an image with such sha as tag, it won't build the image again.

Tested with this scenario:
* I started the entire set of applications once
  * --> every images has been built
* I stopped everything, and started again
  * --> no image has been built
* I stopped everything, I changed the branch only for `io-functions-app`, I started again
  * --> only io-functions-app has been built